### PR TITLE
sugargame: fix IndexError when pressing keys with pygame 2.x

### DIFF
--- a/sugargame/event.py
+++ b/sugargame/event.py
@@ -27,6 +27,28 @@ import pygame
 import pygame.event
 
 
+class KeyStateMap:
+    def __init__(self):
+        self._data = {}
+
+    def __getitem__(self, key):
+        return self._data.get(key, 0)
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+    def __len__(self):
+        return max(self._data.keys(), default=0) + 1
+
+    def __iter__(self):
+        if not self._data:
+            return iter([])
+        return (self._data.get(i, 0) for i in range(len(self)))
+
+    def __contains__(self, key):
+        return key in self._data
+
+
 class _MockEvent(object):
     def __init__(self, keyval):
         self.keyval = keyval
@@ -100,7 +122,7 @@ class Translator(object):
         self._inner_evb.connect('screen-changed', self._screen_changed_cb)
 
         # Internal data
-        self.__keystate = [0] * 323
+        self.__keystate = KeyStateMap()
         self.__button_state = [0, 0, 0]
         self.__mouse_pos = (0, 0)
         self.__repeat = (None, None)


### PR DESCRIPTION
## Problem
Fixes #67

Pressing any key (Shift, Ctrl, Alt etc.) on Ubuntu 24.04 with Python 3.12 + pygame 2.5.2 crashes immediately:
IndexError: list index out of range

## Root Cause

`__keystate` was initialized as a fixed-size list of 323 elements:
```python
self.__keystate = [0] * 323
```

In pygame 1.x all keycodes were between 0–322. In pygame 2.x keycodes were remapped to much larger values:

| Key     | pygame 1.x | pygame 2.x |
|---------|------------|------------|
| Shift_L | 304        | 65505      |
| Ctrl_L  | 306        | 65507      |
| Alt_L   | 308        | 65513      |

So accessing `self.__keystate[65505]` on a 323-element list raises `IndexError` immediately on any keypress.

## Fix

Replace the fixed-size list with a `KeyStateMap` class that uses a dictionary internally and handles any keycode value safely:
```python
# Before
self.__keystate = [0] * 323

# After
self.__keystate = KeyStateMap()
```

`KeyStateMap` implements the full sequence interface making it a drop-in replacement with no other changes needed anywhere:

| Method | Purpose |
|---|---|
| `__getitem__` | returns 0 (not pressed) for any unknown keycode |
| `__setitem__` | stores key state |
| `__len__` | covers range of all stored keycodes |
| `__iter__` | iterates sequentially like a list |
| `__contains__` | supports `in` operator |

## Testing

Simulated a `Shift_L` keypress (keyval 65505) before and after the fix:

**Before:**
keyval: 65505
BUG REPRODUCED: IndexError - list index out of range

**After:**
keyval: 65505
FIX WORKS: No IndexError!

Also verified that `pygame.key.get_pressed()` is never called anywhere in the game code, so the type change from list to `KeyStateMap` has zero impact on the rest of the codebase.